### PR TITLE
Update ForgeRock dependencies to community edition

### DIFF
--- a/modules/login/pom.xml
+++ b/modules/login/pom.xml
@@ -89,6 +89,10 @@
           <groupId>javax.servlet</groupId>
           <artifactId>servlet-api</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-bundle</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/modules/login/src/main/java/edu/mit/ll/nics/servlet/RegisterServlet.java
+++ b/modules/login/src/main/java/edu/mit/ll/nics/servlet/RegisterServlet.java
@@ -252,11 +252,10 @@ public class RegisterServlet extends HttpServlet implements Servlet {
 				}
 			} catch(Exception e) {
 				logger.error("Failed to retrieve workspaces or organization data", e);
-				throw e;
 			}
 			
 			
-		} catch (WebApplicationException | ProcessingException | URISyntaxException e) {
+		} catch (WebApplicationException | ProcessingException e) {
 			//logger.error("Failed to retrieve available workspaces", e);
 			req.setAttribute(ERROR_MESSAGE_KEY, REGISTER_ERROR_CONFIGURATION_MESSAGE);
 			req.setAttribute(ERROR_DESCRIPTION_KEY, REGISTER_ERROR_APIERROR_DESCRIPTION);


### PR DESCRIPTION
ForgeRock has removed access to compiled artifacts that are not "community edition". This broke the NICS build which was relying on these Maven artifacts. This pull request switches the build to use the latest community edition of OpenAM.

Depends on:
1stResponder/nics-tools/pull/1